### PR TITLE
Feat: 회원 정보 저장 및 마이페이지 API 일부 연결

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4,6 +4,8 @@ PODS:
   - Flutter (1.0.0)
   - flutter_localization (0.0.1):
     - Flutter
+  - flutter_secure_storage (6.0.0):
+    - Flutter
   - fluttertoast (0.0.2):
     - Flutter
     - Toast
@@ -25,6 +27,7 @@ DEPENDENCIES:
   - camera_avfoundation (from `.symlinks/plugins/camera_avfoundation/ios`)
   - Flutter (from `Flutter`)
   - flutter_localization (from `.symlinks/plugins/flutter_localization/ios`)
+  - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
   - image_gallery_saver (from `.symlinks/plugins/image_gallery_saver/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
@@ -43,6 +46,8 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_localization:
     :path: ".symlinks/plugins/flutter_localization/ios"
+  flutter_secure_storage:
+    :path: ".symlinks/plugins/flutter_secure_storage/ios"
   fluttertoast:
     :path: ".symlinks/plugins/fluttertoast/ios"
   image_gallery_saver:
@@ -60,7 +65,8 @@ SPEC CHECKSUMS:
   camera_avfoundation: dd002b0330f4981e1bbcb46ae9b62829237459a4
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_localization: f43b18844a2b3d2c71fd64f04ffd6b1e64dd54d4
-  fluttertoast: e9a18c7be5413da53898f660530c56f35edfba9c
+  flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be
+  fluttertoast: 9f2f8e81bb5ce18facb9748d7855bf5a756fe3db
   image_gallery_saver: cb43cc43141711190510e92c460eb1655cd343cb
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   Toast: 1f5ea13423a1e6674c4abdac5be53587ae481c4e

--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -1,0 +1,46 @@
+import 'package:get/get.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class AuthController extends GetxController {
+  final FlutterSecureStorage _storage = const FlutterSecureStorage(
+      aOptions: AndroidOptions(encryptedSharedPreferences: true),
+      iOptions: IOSOptions(
+          synchronizable: true,
+          accessibility: KeychainAccessibility.first_unlock));
+  var isLoggedIn = false.obs;
+  var accessToken = RxnString();
+  var refreshToken = RxnString();
+
+  Future<void> login(String access, String refresh) async {
+    await _storage.write(key: 'accessToken', value: access);
+    await _storage.write(key: 'refreshToken', value: refresh);
+
+    accessToken.value = access;
+    refreshToken.value = refresh;
+    isLoggedIn.value = true;
+
+    // // 확인용 콘솔 출력
+    // print("Access Token Saved: $access");
+    // print("Refresh Token Saved: $refresh");
+  }
+
+  Future<void> logout() async {
+    await _storage.delete(key: 'accessToekn');
+    await _storage.delete(key: 'refreshToken');
+
+    accessToken.value = null;
+    refreshToken.value = null;
+    isLoggedIn.value = false;
+  }
+
+  Future<void> loadLoginInfo() async {
+    accessToken.value = await _storage.read(key: 'accessToken');
+    refreshToken.value = await _storage.read(key: 'refreshToken');
+    isLoggedIn.value = accessToken.value != null && refreshToken.value != null;
+
+    // // 확인용  콘솔 출력
+    // print("Access Token Loaded: ${accessToken.value}");
+    // print("Refresh Token Loaded: ${refreshToken.value}");
+    // print("Is Logged In: ${isLoggedIn.value}");
+  }
+}

--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -12,16 +12,18 @@ class AuthController extends GetxController {
   var refreshToken = RxnString();
 
   Future<void> login(String access, String refresh) async {
+    // login_api에서 받은 토큰 값을 저장소에 저장
     await _storage.write(key: 'accessToken', value: access);
     await _storage.write(key: 'refreshToken', value: refresh);
 
+    // // 저장 후 확인용 코드
+    // print("Access Token Saved: ${await _storage.read(key: 'accessToken')}");
+    // print("Refresh Token Saved: ${await _storage.read(key: 'refreshToken')}");
+
+    // AuthController의 상태 변수 업데이트
     accessToken.value = access;
     refreshToken.value = refresh;
     isLoggedIn.value = true;
-
-    // // 확인용 콘솔 출력
-    // print("Access Token Saved: $access");
-    // print("Refresh Token Saved: $refresh");
   }
 
   Future<void> logout() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,8 @@ Future<void> main() async {
   await dotenv.load(fileName: ".env");
   await initializeDateFormatting('ko_KR', null);
   Get.put(AuthController());
+  final authController = Get.find<AuthController>();
+  await authController.loadLoginInfo();
   runApp(const MyApp());
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:cliving_front/controllers/auth_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get/get.dart';
@@ -7,8 +8,10 @@ import 'screens/join_screen.dart';
 import 'package:intl/date_symbol_data_local.dart';
 
 Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   await dotenv.load(fileName: ".env");
   await initializeDateFormatting('ko_KR', null);
+  Get.put(AuthController());
   runApp(const MyApp());
 }
 

--- a/lib/screens/entry_screen.dart
+++ b/lib/screens/entry_screen.dart
@@ -1,3 +1,5 @@
+import 'package:cliving_front/controllers/auth_controller.dart';
+import 'package:cliving_front/screens/main_screen.dart';
 import 'package:flutter/material.dart';
 import 'dart:async';
 import 'package:get/get.dart';
@@ -15,10 +17,15 @@ class _EntryScreenState extends State<EntryScreen> {
   void initState() {
     super.initState();
 
+    final authController = Get.find<AuthController>();
+
     // 일정 시간 후에 MainScreen으로 이동
-    Timer(const Duration(seconds: 2), () {
-      // 화면 전환
-      Get.off(() => const LoginScreen(), transition: Transition.cupertino);
+    Timer(const Duration(seconds: 1), () {
+      if (authController.isLoggedIn.value) {
+        Get.off(() => const MainScreen(), transition: Transition.cupertino);
+      } else {
+        Get.off(() => const LoginScreen(), transition: Transition.cupertino);
+      }
     });
   }
 

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,4 +1,6 @@
+import 'package:cliving_front/controllers/auth_controller.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import '../services/login_api.dart';
 import '../widgets/custom_dialog.dart';
 
@@ -11,6 +13,7 @@ class LoginScreen extends StatefulWidget {
 
 class _LoginScreenState extends State<LoginScreen> {
   LoginApi api = LoginApi();
+  final AuthController authController = Get.find<AuthController>();
 
   late String id;
   late String password;
@@ -18,6 +21,7 @@ class _LoginScreenState extends State<LoginScreen> {
   void login() async {
     bool check = await api.login(id, password);
     if (check) {
+      await authController.login('access_token', 'refresh_token');
       Navigator.pushNamedAndRemoveUntil(context, '/main', (route) => false);
     } else {
       showMyDialog(context, "로그인 실패", "로그인을 실패하였습니다. 아이디와 비밀번호를 확인해주세요.");

--- a/lib/screens/mypage_screen.dart
+++ b/lib/screens/mypage_screen.dart
@@ -243,11 +243,18 @@ class _MyPageScreenState extends State<MyPageScreen> {
                           right: 5,
                           child: IconButton(
                             onPressed: () {
-                              Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                      builder: (context) =>
-                                          const SettingScreen()));
+                              showModalBottomSheet(
+                                context: context,
+                                isScrollControlled:
+                                    true, // Bottom Sheet 높이 제어 가능
+                                shape: const RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.vertical(
+                                      top: Radius.circular(25.0)),
+                                ),
+                                builder: (BuildContext context) {
+                                  return const SettingScreen(); // SettingScreen을 Bottom Sheet로 표시
+                                },
+                              );
                             },
                             icon: const Icon(Icons.settings_sharp),
                             iconSize: 23,

--- a/lib/screens/mypage_screen.dart
+++ b/lib/screens/mypage_screen.dart
@@ -5,9 +5,13 @@ import 'package:cliving_front/screens/setting_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:get/get.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:intl/intl.dart';
 import 'package:http/http.dart' as http;
+
+import '../controllers/auth_controller.dart';
+import '../services/mypage_api.dart';
 
 class MyPageScreen extends StatefulWidget {
   const MyPageScreen({super.key});
@@ -47,6 +51,8 @@ Widget _settingItems(String title, bool isLast, Function onTapAction) {
 }
 
 class _MyPageScreenState extends State<MyPageScreen> {
+  final authController = Get.find<AuthController>();
+  Map<String, dynamic>? userProfile;
   DateTime _selectedDate = DateTime.now();
   bool _isYearly = false;
   double xAlign = -1;
@@ -58,8 +64,17 @@ class _MyPageScreenState extends State<MyPageScreen> {
   @override
   void initState() {
     super.initState();
+    _loadUserProfile();
     annualTime = _getAnnualTime();
     monthlyTime = _getMonthlyTime();
+  }
+
+  Future<void> _loadUserProfile() async {
+    final profile = await UserService().fetchUserProfile();
+    setState(() {
+      userProfile = profile;
+      print(profile);
+    });
   }
 
   // 월 이동 함수
@@ -195,26 +210,26 @@ class _MyPageScreenState extends State<MyPageScreen> {
                             ),
                           ],
                         ),
-                        const Positioned(
+                        Positioned(
                           top: 20,
                           left: 120,
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               Text(
-                                "임혜진 님",
-                                style: TextStyle(
+                                "${userProfile?['username']} 님",
+                                style: const TextStyle(
                                   fontWeight: FontWeight.w500,
                                   fontSize: 18,
                                 ),
                               ),
-                              SizedBox(
+                              const SizedBox(
                                 height: 10,
                               ),
-                              Text(
+                              const Text(
                                 "3레벨 클라이머",
                               ),
-                              SizedBox(
+                              const SizedBox(
                                 height: 4,
                               ),
                             ],

--- a/lib/screens/mypage_screen.dart
+++ b/lib/screens/mypage_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:cliving_front/charts/pie_chart.dart';
+import 'package:cliving_front/screens/login_screen.dart';
 import 'package:cliving_front/screens/setting_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
@@ -465,7 +466,10 @@ class _MyPageScreenState extends State<MyPageScreen> {
                     },
                   ),
                   _settingItems("작성한 게시물", false, () {}),
-                  _settingItems("로그아웃", false, () {}),
+                  _settingItems("로그아웃", false, () {
+                    authController.logout();
+                    Get.to(() => const LoginScreen());
+                  }),
                 ],
               ),
             ),

--- a/lib/screens/mypage_screen.dart
+++ b/lib/screens/mypage_screen.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:cliving_front/charts/pie_chart.dart';
 import 'package:cliving_front/screens/login_screen.dart';
 import 'package:cliving_front/screens/setting_screen.dart';
+import 'package:cliving_front/services/logout_api.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -52,6 +53,7 @@ Widget _settingItems(String title, bool isLast, Function onTapAction) {
 }
 
 class _MyPageScreenState extends State<MyPageScreen> {
+  final LogoutApi logoutApi = LogoutApi();
   final authController = Get.find<AuthController>();
   Map<String, dynamic>? userProfile;
   DateTime _selectedDate = DateTime.now();
@@ -466,9 +468,15 @@ class _MyPageScreenState extends State<MyPageScreen> {
                     },
                   ),
                   _settingItems("작성한 게시물", false, () {}),
-                  _settingItems("로그아웃", false, () {
-                    authController.logout();
-                    Get.to(() => const LoginScreen());
+                  _settingItems("로그아웃", false, () async {
+                    bool success = await logoutApi.logout();
+                    if (success) {
+                      Get.offAll(
+                          () => const LoginScreen()); // 모든 화면을 닫고 로그인 화면으로 이동
+                    } else {
+                      Get.snackbar(
+                          "Logout Failed", "Please try again."); // 실패 메시지 표시
+                    }
                   }),
                 ],
               ),

--- a/lib/screens/setting_screen.dart
+++ b/lib/screens/setting_screen.dart
@@ -8,8 +8,136 @@ class SettingScreen extends StatefulWidget {
 }
 
 class _SettingScreenState extends State<SettingScreen> {
+  bool isObscurePassword = true;
+
   @override
   Widget build(BuildContext context) {
-    return Container();
+    return Padding(
+      padding: const EdgeInsets.all(15.0),
+      child: GestureDetector(
+        onTap: () {
+          FocusScope.of(context).unfocus();
+        },
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Center(
+            //   child: Stack(
+            //     children: [
+            //       Container(
+            //         width: 130,
+            //         height: 130,
+            //         decoration: BoxDecoration(
+            //           border: Border.all(width: 2, color: Colors.white),
+            //           boxShadow: [
+            //             BoxShadow(
+            //               spreadRadius: 2,
+            //               blurRadius: 10,
+            //               color: Colors.black.withOpacity(0.1),
+            //             )
+            //           ],
+            //           shape: BoxShape.circle,
+            //           image: const DecorationImage(
+            //             fit: BoxFit.cover,
+            //             image: AssetImage('assets/images/profile_image.png'),
+            //           ),
+            //         ),
+            //       ),
+            //       Positioned(
+            //         bottom: 0,
+            //         right: 0,
+            //         child: Container(
+            //           height: 40,
+            //           width: 40,
+            //           decoration: BoxDecoration(
+            //             shape: BoxShape.circle,
+            //             border: Border.all(width: 4, color: Colors.white),
+            //             color: Colors.blue,
+            //           ),
+            //           child: const Icon(Icons.edit, color: Colors.white),
+            //         ),
+            //       ),
+            //     ],
+            //   ),
+            // ),
+            const SizedBox(height: 20),
+            buildTextField("닉네임", "Imagine", false),
+            buildTextField("전화번호", "01012345678", false),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                OutlinedButton(
+                  onPressed: () {},
+                  style: OutlinedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(horizontal: 50),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                  ),
+                  child: const Text(
+                    "취소",
+                    style: TextStyle(
+                      fontSize: 15,
+                      letterSpacing: 2,
+                      color: Colors.black,
+                    ),
+                  ),
+                ),
+                ElevatedButton(
+                  onPressed: () {},
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(horizontal: 50),
+                    backgroundColor: Colors.blue,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                  ),
+                  child: const Text(
+                    "저장",
+                    style: TextStyle(
+                      fontSize: 15,
+                      letterSpacing: 2,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget buildTextField(
+      String labelText, String placeholder, bool isPasswordTextField) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 30),
+      child: TextField(
+        obscureText: isPasswordTextField ? isObscurePassword : false,
+        decoration: InputDecoration(
+          suffixIcon: isPasswordTextField
+              ? IconButton(
+                  icon: const Icon(Icons.remove_red_eye, color: Colors.grey),
+                  onPressed: () {
+                    setState(() {
+                      isObscurePassword = !isObscurePassword;
+                    });
+                  },
+                )
+              : null,
+          contentPadding: const EdgeInsets.only(bottom: 5),
+          labelText: labelText,
+          floatingLabelBehavior: FloatingLabelBehavior.always,
+          hintText: placeholder,
+          hintStyle: const TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
+            color: Colors.grey,
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/services/login_api.dart
+++ b/lib/services/login_api.dart
@@ -1,6 +1,8 @@
+import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'dart:convert'; // for jsonEncode
+import 'dart:convert';
+import '../controllers/auth_controller.dart'; // for jsonEncode
 
 class LoginApi {
   final String API_ADDRESS = dotenv.get('API_ADDRESS'); // 환경 변수 불러오기
@@ -29,8 +31,17 @@ class LoginApi {
 
     // 응답 처리
     if (response.statusCode == 200) {
-      // 성공 시 응답 바디 출력
-      print("Response: ${utf8.decode(response.bodyBytes)}");
+      // 로그인 성공 시 서버 응답을 파싱하여 토큰 저장
+      final data = jsonDecode(utf8.decode(response.bodyBytes));
+      final accessToken = data['access'];
+      final refreshToken = data['refresh'];
+
+      // AuthController에 토큰 저장
+      final AuthController authController = Get.find<AuthController>();
+      authController.login(accessToken, refreshToken);
+
+      // print("Access Token: $accessToken");
+      // print("Refresh Token: $refreshToken");
       return true;
     } else {
       // 실패 시 에러 출력

--- a/lib/services/logout_api.dart
+++ b/lib/services/logout_api.dart
@@ -1,0 +1,45 @@
+import 'package:get/get.dart';
+import 'package:http/http.dart' as http;
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'dart:convert';
+import '../controllers/auth_controller.dart'; // for jsonEncode
+
+class LogoutApi {
+  final String API_ADDRESS = dotenv.get('API_ADDRESS'); // 환경 변수 불러오기
+  late Uri uri;
+
+  Future<bool> logout() async {
+    uri = Uri.parse('$API_ADDRESS/api/users/auth/logout/');
+    final AuthController authController = Get.find<AuthController>();
+    final accessToken = authController.accessToken.value;
+    final refreshToken = authController.refreshToken.value;
+
+    // 요청 바디 데이터 (JSON 형식)
+    Map<String, String> body = {'refresh': '$refreshToken'};
+
+    // 헤더 설정
+    Map<String, String> headers = {
+      'Authorization': 'Bearer $accessToken',
+      'Content-Type': 'application/json', // JSON 데이터를 보내기 위해 Content-Type 설정
+    };
+
+    // HTTP POST 요청
+    final response = await http.post(
+      uri,
+      headers: headers,
+      body: jsonEncode(body), // body를 JSON 형식으로 변환
+    );
+
+    // 응답 처리
+    if (response.statusCode == 200) {
+      // AuthController에 토큰 저장
+      authController.logout();
+      return true;
+    } else {
+      // 실패 시 에러 출력
+      print(
+          "Failed to logout: ${response.statusCode}, ${utf8.decode(response.bodyBytes)}");
+      return false;
+    }
+  }
+}

--- a/lib/services/mypage_api.dart
+++ b/lib/services/mypage_api.dart
@@ -1,0 +1,35 @@
+import 'package:cliving_front/controllers/auth_controller.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:get/get.dart';
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+
+class UserService {
+  final AuthController authController = Get.find<AuthController>();
+  final String API_ADDRESS = dotenv.get('API_ADDRESS');
+  late Uri uri;
+
+  Future<Map<String, dynamic>?> fetchUserProfile() async {
+    final accessToken = authController.accessToken.value;
+    print(accessToken);
+    print("??");
+    print("Authorization Header: Bearer $accessToken");
+
+    Map<String, String> headers = {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer $accessToken',
+    };
+    print(API_ADDRESS);
+    final url = Uri.parse('$API_ADDRESS/api/users/profile/');
+
+    final response = await http.get(url, headers: headers);
+
+    if (response.statusCode == 200) {
+      // 성공적으로 사용자 정보 가져옴
+      return json.decode(response.body);
+    } else {
+      print("Failed to fetch profile: ${response.statusCode}");
+      return null;
+    }
+  }
+}

--- a/lib/services/mypage_api.dart
+++ b/lib/services/mypage_api.dart
@@ -11,15 +11,12 @@ class UserService {
 
   Future<Map<String, dynamic>?> fetchUserProfile() async {
     final accessToken = authController.accessToken.value;
-    print(accessToken);
-    print("??");
     print("Authorization Header: Bearer $accessToken");
 
     Map<String, String> headers = {
       'Content-Type': 'application/json',
       'Authorization': 'Bearer $accessToken',
     };
-    print(API_ADDRESS);
     final url = Uri.parse('$API_ADDRESS/api/users/profile/');
 
     final response = await http.get(url, headers: headers);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   url_launcher: ^6.3.0
   camera_avfoundation: ^0.9.17+3
   gap: ^3.0.1
+  flutter_secure_storage: ^8.1.0
 
 
   


### PR DESCRIPTION
`flutter_secure_storage` 패키지를 설치하여 앱 종료 후에도 로그인 상태를 유지할 수 있도록 하였습니다. 로그인 시 발급받은 토큰 값을 저장소에 저장하고, 저장된 토큰 값이 있다면 다시 로그인 할 필요 없이 메인 페이지로 이동합니다. 반대로 로그아웃 시에는 저장된 토큰을 삭제하고, logout API를 호출하여 토큰을 만료시킵니다. 또한 로그인 상태를 전역으로 관리하기 위해 상태관리 패키지 GetX를 사용했습니다. 이를 통해 로그인 상태와 사용자 정보를 앱 전역에서 관리할 수 있도록 할 것입니다.

마이페이지 API를 연결하여 마이페이지에서 사용자의 닉네임을 받아올 수 있도록 했습니다. 이에 이어서 닉네임 수정, 프로필 수정 등의 프로필 업데이트 기능을 구현할 예정입니다.