### PR TITLE
Fix: failed fetch events 버그 해결

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -470,14 +470,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = LYRURA8XC9;
+				DEVELOPMENT_TEAM = GA8QCJHNK2;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.clivingFront;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cliving.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -654,14 +654,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = LYRURA8XC9;
+				DEVELOPMENT_TEAM = GA8QCJHNK2;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.clivingFront;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cliving.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -678,14 +678,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = LYRURA8XC9;
+				DEVELOPMENT_TEAM = GA8QCJHNK2;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.clivingFront;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cliving.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";

--- a/lib/screens/loading_screen.dart
+++ b/lib/screens/loading_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class LoadingScreen extends StatelessWidget {
+  const LoadingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircularProgressIndicator(),
+            SizedBox(height: 20),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,5 +1,7 @@
 import 'package:cliving_front/controllers/auth_controller.dart';
 import 'package:cliving_front/screens/change_password_verify_screen.dart';
+import 'package:cliving_front/screens/entry_screen.dart';
+import 'package:cliving_front/screens/loading_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../services/login_api.dart';
@@ -22,8 +24,20 @@ class _LoginScreenState extends State<LoginScreen> {
   void login() async {
     bool check = await api.login(id, password);
     if (check) {
+      Get.to(() => const LoadingScreen());
+
+      // AuthController가 `accessToken`과 사용자 프로필 정보를 가져올 때까지 기다림
+      await authController.loadLoginInfo();
+
+      // `accessToken`이 설정되었는지 확인
+      while (authController.accessToken.value == null ||
+          authController.accessToken.value!.isEmpty) {
+        await Future.delayed(const Duration(milliseconds: 100));
+      }
+
       Navigator.pushNamedAndRemoveUntil(context, '/main', (route) => false);
     } else {
+      Get.off(() => const LoginScreen());
       showMyDialog(context, "로그인 실패", "로그인을 실패하였습니다. 아이디와 비밀번호를 확인해주세요.");
     }
   }


### PR DESCRIPTION
authController.accessToken의 값이 설정되기 전에 이벤트를 가져오는 API가 호출되기 때문에 Unauthorized 문제가 발생했습니다. 

로그인 후 AuthController에서 accessToken이 비동기로 설정되기 때문에 캘린더 화면에 도달했을 때 아직 accessToken이 유효하지 않을 수 있습니다. 하지만 메인 페이지(캘린더 페이지)가 생성(initState)되자마자 fetchEvents API가 호출되기 때문에 API 호출에 실패합니다. 

따라서 로딩하는 화면을 추가하여 로딩 화면을 보여주다가 accessToken이 준비되면 메인 페이지로 넘어갈 수 있게 했습니다. 토큰이 설정되는데 시간이 오래 걸리지 않아 로딩화면은 거의 보여지지 않습니다. 사용자 관점에서는 바로 화면이 이동하는 것처럼 보입니다.